### PR TITLE
Add trusted session support into the rebar API and CLI.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -14,6 +14,7 @@ import (
 	"path"
 
 	"github.com/VictorLowther/jsonpatch"
+	"github.com/digitalrebar/go-common/cert"
 )
 
 type challenge interface {
@@ -38,6 +39,17 @@ const (
 	// url passed to one of the request functions.
 	API_PATH = "/api/v2"
 )
+
+// TrustedSession builds a Client that can only operate inside the local trust zone.
+// It assumes that there is a local Consul server that it can use to look up the
+// trust-me service and the internal endpoint for the Rebar API.
+func TrustedSession(URL, User string) (*Client, error) {
+	c, err := cert.Client("internal", "rebar-client")
+	if err != nil {
+		return nil, err
+	}
+	return &Client{URL: URL, Client: c, Challenge: challengeTrusted(User)}, nil
+}
 
 // Session establishes a new connection to Rebar.  You must call
 // this function before using any other functions in the rebar

--- a/api/trusted.go
+++ b/api/trusted.go
@@ -1,0 +1,17 @@
+package api
+
+import "net/http"
+
+type challengeTrusted string
+
+// No need to handle parsing the challenge, Rebar
+// will believe we are who we say we are.
+func (c challengeTrusted) parseChallenge(resp *http.Response) error {
+	return nil
+}
+
+// This only works from inside the trust boundary at rev-proxy
+func (c challengeTrusted) authorize(method, uri string, req *http.Request) error {
+	req.Header.Set("X-Authenticated-Username", string(c))
+	return nil
+}


### PR DESCRIPTION
Trusted sessions are to be used when operating in the trust zone -- in
this mode, all communications with the API server are authenticated by
TLS mutual authentication, and the client can effectively act on behalf
of any user.  A trusted session can only be created where the client can
get access to the trust-me service and have it issue an ephemeral
certificate.